### PR TITLE
Adding needed reference to `Statiq.Markdown`

### DIFF
--- a/input/framework/configuration/bootstrapper/adding-pipelines.md
+++ b/input/framework/configuration/bootstrapper/adding-pipelines.md
@@ -70,6 +70,7 @@ To complete building the pipeline call `Build()`:
 ```csharp
 using System;
 using Statiq.App;
+using Statiq.Markdown;
 
 namespace MyGenerator
 {


### PR DESCRIPTION
The `RenderMarkdown()` method is found in the `Statiq.Markdown` nuget package.  I was using these docs to see how to add a markdown renderer; and this is the part I got stuck on because I couldn't find the `RenderMarkdown` class in the `Statiq.App` namespace; turns out, it's in another package entirely.  Adding this using statement so that the code would compile (I hope?).