### PR TITLE
Remove Statiqdev namespace

### DIFF
--- a/input/web/content-and-data/templates/razor.md
+++ b/input/web/content-and-data/templates/razor.md
@@ -9,7 +9,6 @@ Because Statiq uses a custom Razor base page, the Razor Intellisense engine does
 @using Statiq.Razor
 @using Statiq.Web
 @using Statiq.Web.Pipelines
-@using Statiqdev
 @using Microsoft.Extensions.Logging
 
 @inherits StatiqRazorPage<IDocument>


### PR DESCRIPTION
I believe there shoudn't be `@using Statiqdev` using in the `_ViewImports.cshtml` example.