### PR TITLE
Easier add package and link to CleanBlog

### DIFF
--- a/input/web/index.md
+++ b/input/web/index.md
@@ -27,10 +27,10 @@ dotnet new console --name MySite
 In same folder as your newly created project (*i.e. `MySite`*).
 
 ```csharp
-dotnet add package Statiq.Web --version x.y.z
+dotnet add package Statiq.Web --prelease
 ```
 
-Use whatever is the [most recent version of Statiq.Web](https://www.nuget.org/packages/Statiq.Web). The `--version` flag is needed while the package is pre-release.
+The `--prerelease` flag is needed while the package is pre-release.
 
 ## Step 4: Create a Bootstrapper
 
@@ -84,3 +84,7 @@ dotnet run -- preview
 
 This will generate content and serve your output folder over HTTP (i.e. `http://localhost:5080`).
 ![statiq preview](https://user-images.githubusercontent.com/1647294/89655186-0198b580-d8ca-11ea-9db5-bef9a9592161.png)
+
+## Step 7: (Optional) Check out a Blog theme to see Statiq.Web in practice
+
+Go to the [CleanBlog](https://github.com/statiqdev/CleanBlog) repo and import the theme into your project to start exploring a more functional example.


### PR DESCRIPTION
Reduce friction to getting started by adding the --prerelease param and directing users to the CleanBlog starter project.