### PR TITLE
Remove ß character

### DIFF
--- a/input/web/content-and-data/metadata/directory-metadata.md
+++ b/input/web/content-and-data/metadata/directory-metadata.md
@@ -8,4 +8,4 @@ Any metadata defined in a directory metadata file will be applied to all files i
 
 Local metadata in the front matter of a file overrides any defined directory metadata.
 
-Directory metadata support can be globally turned off by [setting](xref:web-settings) `ApplyDirectoryMetadata` to `false`.ß
+Directory metadata support can be globally turned off by [setting](xref:web-settings) `ApplyDirectoryMetadata` to `false`.


### PR DESCRIPTION
Was reading through the documentation for Statiq.Web, and encountered what appears to be an extra character:

I suspect (although could be wrong) that the ß at the end of the file was from someone on a Mac hitting Option(alt) + S instead of Cmd(Win) + S.